### PR TITLE
[Backend] Add the FilesController

### DIFF
--- a/api/app/controllers/files_controller.rb
+++ b/api/app/controllers/files_controller.rb
@@ -1,0 +1,28 @@
+class FilesController < ApplicationController
+  def show
+    return render_repository_not_found unless repository
+
+    source_file = repository.source_files.find_by(filepath: params[:filepath])
+    return render_source_file_not_found unless source_file
+
+    render(json: {
+      filepath: source_file.filepath,
+      commits_count: source_file.commits.count,
+      main_contributor: source_file.main_contributor
+    })
+  end
+
+  private
+
+  def repository
+    @repository ||= Repository.find_by(id: params[:repository_id])
+  end
+
+  def render_repository_not_found
+    render(json: [], status: :not_found)
+  end
+
+  def render_source_file_not_found
+    render(json: { message: "file does not exists." }, status: :not_found)
+  end
+end

--- a/api/app/models/source_file.rb
+++ b/api/app/models/source_file.rb
@@ -13,4 +13,15 @@ class SourceFile < ApplicationRecord
       changes.sum_line_changes
     end
   end
+
+  def main_contributor
+    author, count = commits
+      .group(:author)
+      .order(Arel.sql("count_id DESC"))
+      .limit(1)
+      .count(:id)
+      .first
+
+    { author: author, commits_count: count }.compact
+  end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -14,4 +14,6 @@ Rails.application.routes.draw do
   post "/repositories", to: "repositories#create"
 
   get "/repositories/:repository_id/tree/head", to: "trees#show"
+
+  get "/repositories/:repository_id/files/head/*filepath", to: "files#show", format: false
 end

--- a/api/test/controllers/files_controller_test.rb
+++ b/api/test/controllers/files_controller_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class FilesControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @repository = repositories(:test_repository)
+  end
+
+  test "#show returns 404 when the repository does not exists" do
+    get "/repositories/9999999999/files/head/README.md"
+
+    assert_response(:not_found)
+  end
+
+  test "#show returns 404 when the file does not exists" do
+    get "/repositories/#{@repository.id}/files/head/non_existing_file.txt"
+
+    assert_response(:not_found)
+    assert_equal("file does not exists.", response.parsed_body[:message])
+  end
+
+  test "#show returns 200 when the file exists on the repository" do
+    get "/repositories/#{@repository.id}/files/head/main.rb"
+
+    expected_response = {
+      "filepath" => "main.rb",
+      "commits_count" => source_files(:test_repository_main).commits.size,
+      "main_contributor" => {
+        "author" => "Jonathan Lalande",
+        "commits_count" => 2
+      }
+    }
+
+    assert_response(:ok)
+    assert_equal(expected_response, response.parsed_body)
+  end
+end

--- a/api/test/controllers/trees_controller_test.rb
+++ b/api/test/controllers/trees_controller_test.rb
@@ -15,7 +15,7 @@ class TreesControllerTest < ActionDispatch::IntegrationTest
     files = stub_gitland_repository(:list_all_files_with_size) do
       [
         { "filepath" => "Gemfile", "line_count" => 123 },
-        { "filepath" => "actionpack/lib/action_pack.rb", "line_count" => 27 },
+        { "filepath" => "actionpack/lib/action_pack.rb", "line_count" => 27 }
       ]
     end
 

--- a/api/test/models/source_file_test.rb
+++ b/api/test/models/source_file_test.rb
@@ -18,4 +18,10 @@ class SourceFileTest < ActiveSupport::TestCase
     assert_equal(7, source_files(:test_repository_readme).line_count(revision_id: revision))
     assert_equal(0, source_files(:test_repository_main).line_count(revision_id: revision))
   end
+
+  test "#main_contributor" do
+    file = source_files(:test_repository_main)
+
+    assert_equal({ author: "Jonathan Lalande", commits_count: 2 }, file.main_contributor)
+  end
 end


### PR DESCRIPTION
Part of https://github.com/visevol/GithubVisualisation/issues/41

Add a FilesController.

This controller returns information about a file on a repository.
Right now, it only returns the following information:
- filepath
- commits count
- main contributor

Example:
```
GET /repositories/123/files/head/activejob/lib/active_job.rb

{
  filepath: "activejob/lib/active_job.rb",
  commits_count: 75,
  main_contributor: {
    author: "Ryuta Kamizono",
    commits_count: 7
  }
}
```