### PR TITLE
[Backend] Fix SourceFile#main_contributor

### DIFF
--- a/api/app/models/source_file.rb
+++ b/api/app/models/source_file.rb
@@ -16,6 +16,7 @@ class SourceFile < ApplicationRecord
 
   def main_contributor
     author, count = commits
+      .where(for_changes_ledger: false)
       .group(:author)
       .order(Arel.sql("count_id DESC"))
       .limit(1)

--- a/api/test/controllers/files_controller_test.rb
+++ b/api/test/controllers/files_controller_test.rb
@@ -26,7 +26,7 @@ class FilesControllerTest < ActionDispatch::IntegrationTest
       "commits_count" => source_files(:test_repository_main).commits.size,
       "main_contributor" => {
         "author" => "Jonathan Lalande",
-        "commits_count" => 2
+        "commits_count" => 1
       }
     }
 

--- a/api/test/models/source_file_test.rb
+++ b/api/test/models/source_file_test.rb
@@ -22,6 +22,6 @@ class SourceFileTest < ActiveSupport::TestCase
   test "#main_contributor" do
     file = source_files(:test_repository_main)
 
-    assert_equal({ author: "Jonathan Lalande", commits_count: 2 }, file.main_contributor)
+    assert_equal({ author: "Jonathan Lalande", commits_count: 1 }, file.main_contributor)
   end
 end


### PR DESCRIPTION
Closes: https://github.com/visevol/GithubVisualisation/issues/53

Only count non merge commits in SourceFile#main_contributor.