### PR TITLE
[Backend] Add `CommitsController` and `#commits_over_time` action

### DIFF
--- a/api/app/controllers/commits_controller.rb
+++ b/api/app/controllers/commits_controller.rb
@@ -1,0 +1,29 @@
+class CommitsController < ApplicationController
+  def commits_over_time
+    return render_repository_not_found unless repository
+
+    stats = RepositoryStatisticsService
+      .new(repository)
+      .commits_statistics_by_date
+      .map! do |date, commits_count, file_changed, line_changed|
+        {
+          date: date,
+          commits_count: commits_count,
+          modified_files: file_changed,
+          modified_lines: line_changed
+        }
+      end
+
+    render(json: stats)
+  end
+
+  private
+
+  def repository
+    @repository ||= Repository.find_by(id: params[:repository_id])
+  end
+
+  def render_repository_not_found
+    render(json: [], status: :not_found)
+  end
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -16,4 +16,6 @@ Rails.application.routes.draw do
   get "/repositories/:repository_id/tree/head", to: "trees#show"
 
   get "/repositories/:repository_id/files/head/*filepath", to: "files#show", format: false
+
+  get "/repositories/:repository_id/commits/stats/commits_over_time", to: "commits#commits_over_time"
 end

--- a/api/db/migrate/20241020003703_add_index_on_commits_committer_date.rb
+++ b/api/db/migrate/20241020003703_add_index_on_commits_committer_date.rb
@@ -1,0 +1,5 @@
+class AddIndexOnCommitsCommitterDate < ActiveRecord::Migration[8.0]
+  def change
+    add_index :commits, [ :repository_id, :for_changes_ledger, :committer_date ]
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_10_13_222300) do
+ActiveRecord::Schema[8.0].define(version: 2024_10_20_003703) do
   create_table "commits", force: :cascade do |t|
     t.integer "repository_id"
     t.string "commit_hash"
@@ -19,6 +19,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_10_13_222300) do
     t.datetime "author_date"
     t.boolean "for_changes_ledger", default: false
     t.index ["repository_id", "commit_hash"], name: "index_commits_on_repository_id_and_commit_hash", unique: true
+    t.index ["repository_id", "for_changes_ledger", "committer_date"], name: "idx_on_repository_id_for_changes_ledger_committer_d_f429cd9db3"
   end
 
   create_table "repositories", force: :cascade do |t|

--- a/api/test/controllers/commits_controller_test.rb
+++ b/api/test/controllers/commits_controller_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class CommitsControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @repository = repositories(:test_repository)
+  end
+
+  test "#commits_over_time returns 404 if the repository does not exists" do
+    get "/repositories/9999999999/commits/stats/commits_over_time"
+
+    assert_response(:not_found)
+  end
+
+  test "#commits_over_time returns 200 if the repository exists" do
+    get "/repositories/#{@repository.id}/commits/stats/commits_over_time"
+
+    assert_response(:ok)
+    assert_equal(
+      [
+        {
+          "date" => "2024-10-13",
+          "commits_count" => 1,
+          "modified_files" => 1,
+          "modified_lines" => 7
+        },
+        {
+          "date" => "2024-10-15",
+          "commits_count" => 1,
+          "modified_files" => 1,
+          "modified_lines" => 1
+        }
+      ],
+      response.parsed_body
+    )
+  end
+end

--- a/api/test/fixtures/commits.yml
+++ b/api/test/fixtures/commits.yml
@@ -30,13 +30,13 @@ test_repository_1bd82e:
   repository: test_repository
   commit_hash: 1bd82e1b47706d021c419c5c4b0363bc90892039
   author: Jonathan Lalande
-  committer_date: 2024-10-13
-  author_date: 2024-10-13
+  committer_date: 2024-10-15
+  author_date: 2024-10-15
 
 test_repository_c7dc1a:
   repository: test_repository
   commit_hash: c7dc1aec5968621f63944cf41888d3000bed44fc
   author: Jonathan Lalande
-  committer_date: 2024-10-13
-  author_date: 2024-10-13
+  committer_date: 2024-10-15
+  author_date: 2024-10-15
   for_changes_ledger: true


### PR DESCRIPTION
Part of https://github.com/visevol/GithubVisualisation/issues/50

Add a controller action that returns data points that describes a stream of commit over time. Each data point is a date, and a description of what changed that date.

Example:

```
GET /repositories/123/commits/stats/commits_over_time

[
  { 
    date: "2010-01-01", 
    commit_counts: 6,
    modified_lines: 49, 
    modified_files: 13,
  },
  ...
]
```