### PR TITLE
[Backend] Add date filtering on commits over time endpoint

### DIFF
--- a/api/app/controllers/commits_controller.rb
+++ b/api/app/controllers/commits_controller.rb
@@ -4,7 +4,7 @@ class CommitsController < ApplicationController
 
     stats = RepositoryStatisticsService
       .new(repository)
-      .commits_statistics_by_date
+      .commits_statistics_by_date(start_date: start_date_filter, end_date: end_date_filter)
       .map! do |date, commits_count, file_changed, line_changed|
         {
           date: date,
@@ -25,5 +25,17 @@ class CommitsController < ApplicationController
 
   def render_repository_not_found
     render(json: [], status: :not_found)
+  end
+
+  def start_date_filter
+    DateTime.parse(params[:start_date])
+  rescue
+    nil
+  end
+
+  def end_date_filter
+    DateTime.parse(params[:end_date])
+  rescue
+    nil
   end
 end

--- a/api/app/services/repository_statistics_service.rb
+++ b/api/app/services/repository_statistics_service.rb
@@ -16,9 +16,11 @@ class RepositoryStatisticsService
   #   line changed      <-- the net number of line changed that day
   # ]
   #
-  def commits_statistics_by_date
-    @repository.commits
-      .on_changes_ledger
+  def commits_statistics_by_date(start_date: nil, end_date: nil)
+    scope = @repository.commits.on_changes_ledger
+    scope = scope.where(committer_date: start_date..) if start_date
+    scope = scope.where(committer_date: ..end_date) if end_date
+    scope
       .joins(:source_file_changes)
       .group(:committer_date)
       .pluck(

--- a/api/test/controllers/commits_controller_test.rb
+++ b/api/test/controllers/commits_controller_test.rb
@@ -33,4 +33,45 @@ class CommitsControllerTest < ActionDispatch::IntegrationTest
       response.parsed_body
     )
   end
+
+  test "#commits_over_time output is filtered by `start_date` parameter" do
+    get "/repositories/#{@repository.id}/commits/stats/commits_over_time?start_date=2024-10-14"
+
+    assert_response(:ok)
+    assert_equal(
+      [
+        {
+          "date" => "2024-10-15",
+          "commits_count" => 1,
+          "modified_files" => 1,
+          "modified_lines" => 1
+        }
+      ],
+      response.parsed_body
+    )
+  end
+
+  test "#commits_over_time output is filtered by `end_date` parameter" do
+    get "/repositories/#{@repository.id}/commits/stats/commits_over_time?end_date=2024-10-14"
+
+    assert_response(:ok)
+    assert_equal(
+      [
+        {
+          "date" => "2024-10-13",
+          "commits_count" => 1,
+          "modified_files" => 1,
+          "modified_lines" => 7
+        }
+      ],
+      response.parsed_body
+    )
+  end
+
+  test "#commits_over_time output is filtered by both `start_date` and `end_date` parameter" do
+    get "/repositories/#{@repository.id}/commits/stats/commits_over_time?start_date=2020-01-01&end_date=2021-01-01"
+
+    assert_response(:ok)
+    assert_equal([], response.parsed_body)
+  end
 end


### PR DESCRIPTION
Add date filtering on the CommitsController#commits_over_time action. Requests can now include a `start_date` and `end_date` url parameter to filter the data points.

Example:
```
GET /repositories/123/commits/stats/commits_over_time?start_date=2023-01-01

[
  { 
    date: "2023-01-01", 
    commit_counts: 6,
    modified_lines: 49, 
    modified_files: 13,
  },
  ... only data point after 2023-01-01
]
```

```
GET /repositories/123/commits/stats/commits_over_time?end_date=2020-01-01

[
  ... only data point before 2020-01-01
  { 
    date: "2020-01-01", 
    commit_counts: 6,
    modified_lines: 49, 
    modified_files: 13,
  },
]
```

```
GET /repositories/123/commits/stats/commits_over_time?start_date=2020-01-01&end_date=2021-01-01

[
  ... only data point between 2020-01-01 and 2021-01-01
]
```