### PR TITLE
[Backend] Add Gitland::Commands::Log

### DIFF
--- a/api/app/services/gitland/commands/log.rb
+++ b/api/app/services/gitland/commands/log.rb
@@ -1,0 +1,54 @@
+module Gitland
+  module Commands
+    class Log < GitCommand
+      #
+      # Executes the `git log` command on a repository.
+      # Yields an enumerator of lines on the output.
+      #
+      # The command is called with following flag by default:
+      #   --reverse
+      #   --numstat
+      #   --summary
+      #
+      # Example:
+      #
+      #   Gitland::Commands::Log.new(repository).execute do |logs|
+      #     logs.each do |line|
+      #       # do something with the line...
+      #     end
+      #   end
+      #
+      def initialize(repository, format: nil)
+        @repository = repository
+        @format = format
+      end
+
+      def execute
+        return unless block_given?
+
+        cli = Git::CommandLine.new({}, "/usr/bin/git", [], Logger.new("/dev/null"))
+
+        command = [ "log" ]
+        command << "--reverse"
+        command << "--numstat"
+        command << "--summary"
+        command << "--pretty=format:#{@format}" if @format
+
+        Tempfile.create(binmode: true) do |f|
+          cli.run(
+            *command,
+            out: f,
+            err: nil,
+            chdir: Gitland::Storage.new(@repository).absolute_path,
+            normalize: true,
+            merge: false,
+            chomp: true
+          )
+
+          f.rewind
+          yield f.each_line
+        end
+      end
+    end
+  end
+end

--- a/api/test/services/gitland/commands/log_test.rb
+++ b/api/test/services/gitland/commands/log_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+module Gitland
+  module Commands
+    class LogTest < ActiveSupport::TestCase
+      def setup
+        @repository = repositories(:rails)
+      end
+
+      test "#execute calls `git log` with --reverse, --numstat and --summary by default" do
+        Git::CommandLine
+          .any_instance
+          .expects(:run)
+          .with do |*args|
+            command, reverse, numstat, summary = args
+            assert_equal("log", command)
+            assert_equal("--reverse", reverse)
+            assert_equal("--numstat", numstat)
+            assert_equal("--summary", summary)
+          end
+
+        Gitland::Commands::Log.new(@repository).execute { }
+      end
+
+      test "#execute calls `git log` with the format provided in the initializer" do
+        Git::CommandLine
+          .any_instance
+          .expects(:run)
+          .with do |*args|
+            command, _, _, _, format, _ = args
+            assert_equal("log", command)
+            assert_equal("--pretty=format:||%H||%aN||%cs||%as||", format)
+          end
+
+        Gitland::Commands::Log.new(@repository, format: "||%H||%aN||%cs||%as||").execute { }
+      end
+
+      test "#execute redirect cli output to a temporary file" do
+        _, tmp_file = stub_temporary_log_file { "" }
+
+        Git::CommandLine
+          .any_instance
+          .expects(:run)
+          .with do |*args|
+            kwargs = args.last
+            assert_equal(tmp_file, kwargs[:out])
+          end
+
+        Gitland::Commands::Log.new(@repository).execute { }
+      end
+
+      test "#execute yields an enumerable of the lines in the temporary log file" do
+        log_file, _ = stub_temporary_log_file do
+          <<~LOGS
+            ||71c23127bf7bad405dd3e8e29f9394140882898c||Jonathan Lalande||2024-10-06||2024-10-06||
+            2	0	README.md
+             create mode 100644 README.md
+
+            ||3ecab153fab78e61290892881e9a34d0df6fb7a0||Jonathan Lalande||2024-10-10||2024-10-10||
+            3	0	README.md
+          LOGS
+        end
+
+        Git::CommandLine
+          .any_instance
+          .expects(:run)
+
+        Gitland::Commands::Log.new(@repository).execute do |logs|
+          assert_equal(log_file, logs)
+        end
+      end
+
+      private
+
+      def stub_temporary_log_file(&block)
+        log_file = StringIO.new(block.call)
+
+        tmp_file_mock = mock()
+        tmp_file_mock.expects(:rewind).once
+        tmp_file_mock.stubs(:each_line).returns(log_file)
+
+        Tempfile
+          .expects(:create).with(binmode: true)
+          .yields(tmp_file_mock)
+
+        return log_file, tmp_file_mock
+      end
+    end
+  end
+end


### PR DESCRIPTION
TL;DR This command wraps the execution of `git log` on a repository.

Related to https://github.com/visevol/GithubVisualisation/issues/57, first iteration at trying to remove `/lib/git_repository.rb`. 

The RepositorySyncService depends on `lib/git_repository.rb` to generate a log file for a repository. I'm adding a Gitland command to interface `git log` so that RepositorySyncService can use Gitland instead. 