### PR TITLE
[Backend] Change job enqueueing logic when a repo is created

### DIFF
--- a/api/app/jobs/initialize_gitland_repository_job.rb
+++ b/api/app/jobs/initialize_gitland_repository_job.rb
@@ -8,6 +8,9 @@ class InitializeGitlandRepositoryJob < ApplicationJob
       return Rails.logger.info("repository #{repository_id} does not exists.")
     end
 
-    Gitland::CloneRepository.new(repository).execute
+    Gitland::CloneRepository
+      .new(repository)
+      .execute
+      .then { RepositorySyncJob.perform_later(repository_id: repository.id) }
   end
 end

--- a/api/app/jobs/initialize_repository_job.rb
+++ b/api/app/jobs/initialize_repository_job.rb
@@ -1,6 +1,9 @@
-class InitializeGitlandRepositoryJob < ApplicationJob
+class InitializeRepositoryJob < ApplicationJob
   queue_as :default
 
+  #
+  # Initializes a git repository to be consumed by the application.
+  #
   def perform(repository_id:)
     repository = Repository.find_by(id: repository_id)
 

--- a/api/app/models/repository.rb
+++ b/api/app/models/repository.rb
@@ -7,7 +7,6 @@ class Repository < ApplicationRecord
     message: ->(object, _) { "#{object.remote_url} already exists." }
   }
 
-  after_create_commit { RepositorySyncJob.perform_later(repository_id: id) }
   after_create_commit { InitializeGitlandRepositoryJob.perform_later(repository_id: id) }
 
   class << self

--- a/api/app/models/repository.rb
+++ b/api/app/models/repository.rb
@@ -7,7 +7,7 @@ class Repository < ApplicationRecord
     message: ->(object, _) { "#{object.remote_url} already exists." }
   }
 
-  after_create_commit { InitializeGitlandRepositoryJob.perform_later(repository_id: id) }
+  after_create_commit { InitializeRepositoryJob.perform_later(repository_id: id) }
 
   class << self
     def find_by_url(url)

--- a/api/test/jobs/initialize_gitland_repository_job_test.rb
+++ b/api/test/jobs/initialize_gitland_repository_job_test.rb
@@ -1,4 +1,21 @@
 require "test_helper"
 
 class InitializeGitlandRepositoryJobTest < ActiveJob::TestCase
+  def setup
+    @repository = repositories(:test_repository)
+  end
+
+  test "clones the repository" do
+    Gitland::CloneRepository.any_instance.expects(:execute).returns(nil)
+
+    InitializeGitlandRepositoryJob.perform_now(repository_id: @repository.id)
+  end
+
+  test "enqueues a RepositorySyncJob" do
+    Gitland::CloneRepository.any_instance.expects(:execute).returns(nil)
+
+    assert_enqueued_with(job: RepositorySyncJob, args: [ { repository_id: @repository.id } ]) do
+      InitializeGitlandRepositoryJob.perform_now(repository_id: @repository.id)
+    end
+  end
 end

--- a/api/test/jobs/initialize_repository_job_test.rb
+++ b/api/test/jobs/initialize_repository_job_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class InitializeGitlandRepositoryJobTest < ActiveJob::TestCase
+class InitializeRepositoryJobTest < ActiveJob::TestCase
   def setup
     @repository = repositories(:test_repository)
   end
@@ -8,14 +8,14 @@ class InitializeGitlandRepositoryJobTest < ActiveJob::TestCase
   test "clones the repository" do
     Gitland::CloneRepository.any_instance.expects(:execute).returns(nil)
 
-    InitializeGitlandRepositoryJob.perform_now(repository_id: @repository.id)
+    InitializeRepositoryJob.perform_now(repository_id: @repository.id)
   end
 
   test "enqueues a RepositorySyncJob" do
     Gitland::CloneRepository.any_instance.expects(:execute).returns(nil)
 
     assert_enqueued_with(job: RepositorySyncJob, args: [ { repository_id: @repository.id } ]) do
-      InitializeGitlandRepositoryJob.perform_now(repository_id: @repository.id)
+      InitializeRepositoryJob.perform_now(repository_id: @repository.id)
     end
   end
 end

--- a/api/test/models/repository_test.rb
+++ b/api/test/models/repository_test.rb
@@ -38,11 +38,6 @@ class RepositoryTest < ActiveSupport::TestCase
     assert_equal("https://github.com/rails/rails", repositories(:rails).remote_url)
   end
 
-  test "enqueues a RepositorySyncJob after creation" do
-    repository = Repository.create(name: "react", domain: "github.com", path: "/facebook/react")
-    assert_enqueued_with(job: RepositorySyncJob, args: [ { repository_id: repository.id } ])
-  end
-
   test "prevents creation of duplicated repositories on the same domain" do
     repository = Repository.create(name: "rails", domain: "github.com", path: "/rails/rails")
     assert_not(repository.valid?)

--- a/api/test/models/repository_test.rb
+++ b/api/test/models/repository_test.rb
@@ -51,8 +51,8 @@ class RepositoryTest < ActiveSupport::TestCase
     end
   end
 
-  test "enqueues a InitializeGitlandRepositoryJob after creation" do
+  test "enqueues a InitializeRepositoryJob after creation" do
     repository = Repository.create(name: "react", domain: "github.com", path: "/facebook/react")
-    assert_enqueued_with(job: InitializeGitlandRepositoryJob, args: [ { repository_id: repository.id } ])
+    assert_enqueued_with(job: InitializeRepositoryJob, args: [ { repository_id: repository.id } ])
   end
 end


### PR DESCRIPTION
Rename `InitializeGitlandRepositoryJob` to `InitializeRepositoryjob`.

The job now:
- clone the repository
- sync the repository