### PR TITLE
[Backend] Add #file_line_count to Gitland::Repository

### DIFF
--- a/api/app/services/gitland/commands/diff.rb
+++ b/api/app/services/gitland/commands/diff.rb
@@ -9,8 +9,9 @@ module Gitland
       #
       # Executes `git diff <sha_a> <sha_b>`
       #
-      def initialize(repository, sha_a: nil, sha_b: nil)
+      def initialize(repository, filepath: nil, sha_a: nil, sha_b: nil)
         @repository = repository
+        @filepath = filepath
         @sha_a = sha_a
         @sha_b = sha_b
       end
@@ -22,6 +23,7 @@ module Gitland
         command << "--numstat"
         command << @sha_a if sha1_input_valid?(@sha_a)
         command << @sha_b if sha1_input_valid?(@sha_b)
+        command << @filepath if @filepath
 
         cli.run(
           *command,

--- a/api/app/services/gitland/repository.rb
+++ b/api/app/services/gitland/repository.rb
@@ -29,5 +29,18 @@ module Gitland
           }
         end
     end
+
+    def file_line_count(filepath)
+      sha_a = Commands::Diff::EMPTY_DIRECTORY_TREE_HASH
+      sha_b = Commands::Diff::HEAD
+
+      line = Commands::Diff
+        .new(@repository, filepath: filepath, sha_a: sha_a, sha_b: sha_b)
+        .execute
+        .lines
+        .first
+
+      line.strip.split.first.to_i
+    end
   end
 end

--- a/api/test/services/gitland/commands/diff_test.rb
+++ b/api/test/services/gitland/commands/diff_test.rb
@@ -64,6 +64,24 @@ module Gitland
 
         Gitland::Commands::Diff.new(@repository, sha_a: sha_a, sha_b: sha_b).execute
       end
+
+      test "#execute passes filepath to `git diff` if filepath is in the initializer" do
+        mock = mock()
+        mock.expects(:stdout).returns("")
+
+        Git::CommandLine
+          .any_instance
+          .expects(:run)
+          .with do |*args|
+            command, numstat, filepath = args
+            assert_equal("diff", command)
+            assert_equal("--numstat", numstat)
+            assert_equal("api/Gemfile", filepath)
+          end
+          .returns(mock)
+
+        Gitland::Commands::Diff.new(@repository, filepath: "api/Gemfile").execute
+      end
     end
   end
 end

--- a/api/test/services/gitland/repository_test.rb
+++ b/api/test/services/gitland/repository_test.rb
@@ -34,5 +34,26 @@ module Gitland
         Gitland::Repository.new(@repository).list_all_files_with_size
       )
     end
+
+    test "#file_line_count calls Commands::Diff internally" do
+      mocked_diff_output = <<~OUTPUT
+        55      0       api/Gemfile
+      OUTPUT
+
+      command = mock()
+      command.expects(:execute).returns(mocked_diff_output).once
+
+      Commands::Diff
+        .expects(:new)
+        .with(
+          @repository,
+          filepath: "api/Gemfile",
+          sha_a: Commands::Diff::EMPTY_DIRECTORY_TREE_HASH,
+          sha_b: Commands::Diff::HEAD
+        )
+        .returns(command)
+
+      assert_equal(55, Gitland::Repository.new(@repository).file_line_count("api/Gemfile"))
+    end
   end
 end


### PR DESCRIPTION
This method returns the number of line for a specific file.