### PR TITLE
[Backend] Add line_count to output of FilesController#show

### DIFF
--- a/api/app/controllers/files_controller.rb
+++ b/api/app/controllers/files_controller.rb
@@ -8,7 +8,8 @@ class FilesController < ApplicationController
     render(json: {
       filepath: source_file.filepath,
       commits_count: source_file.commits.count,
-      main_contributor: source_file.main_contributor
+      main_contributor: source_file.main_contributor,
+      line_count: source_file.line_count
     })
   end
 

--- a/api/app/models/source_file.rb
+++ b/api/app/models/source_file.rb
@@ -5,13 +5,8 @@ class SourceFile < ApplicationRecord
 
   validates :filepath, uniqueness: { scope: :repository_id }
 
-  def line_count(revision_id: nil)
-    source_file_changes.then do |changes|
-      changes = changes.joins(:commit)
-      changes = changes.merge(Commit.on_changes_ledger)
-      changes = changes.merge(Commit.where(id: ..revision_id)) if revision_id
-      changes.sum_line_changes
-    end
+  def line_count
+    Gitland::Repository.new(self.repository).file_line_count(self.filepath)
   end
 
   def main_contributor

--- a/api/test/controllers/files_controller_test.rb
+++ b/api/test/controllers/files_controller_test.rb
@@ -19,15 +19,19 @@ class FilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#show returns 200 when the file exists on the repository" do
-    get "/repositories/#{@repository.id}/files/head/main.rb"
+    SourceFile.any_instance.stubs(:line_count).returns(69)
+
+    source_file = source_files(:test_repository_main)
+    get "/repositories/#{@repository.id}/files/head/#{source_file.filepath}"
 
     expected_response = {
       "filepath" => "main.rb",
-      "commits_count" => source_files(:test_repository_main).commits.size,
+      "commits_count" => source_file.commits.size,
       "main_contributor" => {
         "author" => "Jonathan Lalande",
         "commits_count" => 1
-      }
+      },
+      "line_count" => 69
     }
 
     assert_response(:ok)

--- a/api/test/models/source_file_test.rb
+++ b/api/test/models/source_file_test.rb
@@ -7,16 +7,14 @@ class SourceFileTest < ActiveSupport::TestCase
     assert(file.errors.of_kind?(:filepath, :taken))
   end
 
-  test "#line_count" do
-    assert_equal(7, source_files(:test_repository_readme).line_count)
-    assert_equal(1, source_files(:test_repository_main).line_count)
-  end
+  test "#line_count uses gitland internally" do
+    source_file = source_files(:test_repository_readme)
 
-  test "#line_count at a specific revision" do
-    revision = commits(:test_repository_6a3e17).id
+    mock_repo = mock()
+    mock_repo.expects(:file_line_count).with(source_file.filepath).returns(7)
+    Gitland::Repository.expects(:new).with(source_file.repository).returns(mock_repo)
 
-    assert_equal(7, source_files(:test_repository_readme).line_count(revision_id: revision))
-    assert_equal(0, source_files(:test_repository_main).line_count(revision_id: revision))
+    assert_equal(7, source_file.line_count)
   end
 
   test "#main_contributor" do


### PR DESCRIPTION
Add the line_count in the response of `FilesController#show`:

![image](https://github.com/user-attachments/assets/28caad17-8722-436b-aaab-cf519bc66b21)
