### PR TITLE
[Backend] Update api schema of `#commits_over_time` endpoint

### DIFF
--- a/api/app/controllers/commits_controller.rb
+++ b/api/app/controllers/commits_controller.rb
@@ -5,12 +5,13 @@ class CommitsController < ApplicationController
     stats = RepositoryStatisticsService
       .new(current_repository)
       .commits_statistics_by_date(start_date: start_date_filter, end_date: end_date_filter)
-      .map! do |date, commits_count, file_changed, line_changed|
+      .map! do |date, commits_count, files_modified, lines_added, lines_removed|
         {
           date: date,
           commits_count: commits_count,
-          modified_files: file_changed,
-          modified_lines: line_changed
+          files_modified: files_modified,
+          lines_added: lines_added,
+          lines_removed: lines_removed
         }
       end
 

--- a/api/app/services/repository_statistics_service.rb
+++ b/api/app/services/repository_statistics_service.rb
@@ -13,7 +13,8 @@ class RepositoryStatisticsService
   #   date,             <-- the date in this format: YYYY-MM-DD
   #   commit count,     <-- the number of commit comitted that day
   #   file changed,     <-- the number of file changed that day
-  #   line changed      <-- the net number of line changed that day
+  #   line added        <-- the number of line added that day
+  #   line removed      <-- the number of line removed that day
   # ]
   #
   def commits_statistics_by_date(start_date: nil, end_date: nil)
@@ -27,7 +28,8 @@ class RepositoryStatisticsService
         Arel.sql("strftime('%Y-%m-%d', committer_date)"),
         Arel.sql("count(distinct commits.id)"),
         Arel.sql("count(distinct source_file_changes.source_file_id)"),
-        Arel.sql("sum(source_file_changes.additions - source_file_changes.deletions)")
+        Arel.sql("sum(source_file_changes.additions)"),
+        Arel.sql("sum(source_file_changes.deletions)"),
       )
   end
 end

--- a/api/test/controllers/commits_controller_test.rb
+++ b/api/test/controllers/commits_controller_test.rb
@@ -20,14 +20,16 @@ class CommitsControllerTest < ActionDispatch::IntegrationTest
         {
           "date" => "2024-10-13",
           "commits_count" => 1,
-          "modified_files" => 1,
-          "modified_lines" => 7
+          "files_modified" => 1,
+          "lines_added" => 7,
+          "lines_removed" => 0
         },
         {
           "date" => "2024-10-15",
           "commits_count" => 1,
-          "modified_files" => 1,
-          "modified_lines" => 1
+          "files_modified" => 1,
+          "lines_added" => 1,
+          "lines_removed" => 0
         }
       ],
       response.parsed_body
@@ -43,8 +45,9 @@ class CommitsControllerTest < ActionDispatch::IntegrationTest
         {
           "date" => "2024-10-15",
           "commits_count" => 1,
-          "modified_files" => 1,
-          "modified_lines" => 1
+          "files_modified" => 1,
+          "lines_added" => 1,
+          "lines_removed" => 0
         }
       ],
       response.parsed_body
@@ -60,8 +63,9 @@ class CommitsControllerTest < ActionDispatch::IntegrationTest
         {
           "date" => "2024-10-13",
           "commits_count" => 1,
-          "modified_files" => 1,
-          "modified_lines" => 7
+          "files_modified" => 1,
+          "lines_added" => 7,
+          "lines_removed" => 0
         }
       ],
       response.parsed_body


### PR DESCRIPTION
The endpoint now returns the number of added and removed lines per date, rather than a number of lines change.

This gives more freedom to the frontend so that it can render different views with the same data set.

Example:
![image](https://github.com/user-attachments/assets/ffadc934-037e-4cec-9a5d-c538de8a1a1c)
