### PR TITLE
[Backend] Add `creation_date` and `last_modification_date` to the response of `FilesController#show`

### DIFF
--- a/api/app/controllers/files_controller.rb
+++ b/api/app/controllers/files_controller.rb
@@ -9,7 +9,9 @@ class FilesController < ApplicationController
       filepath: source_file.filepath,
       commits_count: source_file.commits.count,
       main_contributor: source_file.main_contributor,
-      line_count: source_file.line_count
+      line_count: source_file.line_count,
+      creation_date: source_file.creation_date,
+      last_modification_date: source_file.last_modification_date
     })
   end
 

--- a/api/app/models/source_file.rb
+++ b/api/app/models/source_file.rb
@@ -20,4 +20,12 @@ class SourceFile < ApplicationRecord
 
     { author: author, commits_count: count }.compact
   end
+
+  def creation_date
+    commits.first.committer_date
+  end
+
+  def last_modification_date
+    commits.last.committer_date
+  end
 end

--- a/api/test/controllers/commits_controller_test.rb
+++ b/api/test/controllers/commits_controller_test.rb
@@ -30,6 +30,13 @@ class CommitsControllerTest < ActionDispatch::IntegrationTest
           "files_modified" => 1,
           "lines_added" => 1,
           "lines_removed" => 0
+        },
+        {
+          "date" => "2024-10-27",
+          "commits_count" => 1,
+          "files_modified" => 1,
+          "lines_added" => 2,
+          "lines_removed" => 0
         }
       ],
       response.parsed_body
@@ -47,6 +54,13 @@ class CommitsControllerTest < ActionDispatch::IntegrationTest
           "commits_count" => 1,
           "files_modified" => 1,
           "lines_added" => 1,
+          "lines_removed" => 0
+        },
+        {
+          "date" => "2024-10-27",
+          "commits_count" => 1,
+          "files_modified" => 1,
+          "lines_added" => 2,
           "lines_removed" => 0
         }
       ],

--- a/api/test/controllers/files_controller_test.rb
+++ b/api/test/controllers/files_controller_test.rb
@@ -31,7 +31,9 @@ class FilesControllerTest < ActionDispatch::IntegrationTest
         "author" => "Jonathan Lalande",
         "commits_count" => 1
       },
-      "line_count" => 69
+      "line_count" => 69,
+      "creation_date" => source_file.creation_date.as_json,
+      "last_modification_date" => source_file.last_modification_date.as_json
     }
 
     assert_response(:ok)

--- a/api/test/fixtures/commits.yml
+++ b/api/test/fixtures/commits.yml
@@ -42,3 +42,11 @@ test_repository_c7dc1a:
   committer_date: 2024-10-15
   author_date: 2024-10-15
   for_changes_ledger: true
+
+test_repository_0b8094:
+  repository: test_repository
+  commit_hash: 0b8094d247cb6c22d21fd863222ba5bab59130ca
+  author: Jonathan Lalande
+  committer_date: 2024-10-27
+  author_date: 2024-10-27
+  for_changes_ledger: true

--- a/api/test/fixtures/source_file_changes.yml
+++ b/api/test/fixtures/source_file_changes.yml
@@ -27,3 +27,9 @@ test_repository_c7dc1a_main_rb:
   source_file: test_repository_main
   additions: 1
   deletions: 0
+
+test_repository_0b8094_readme:
+  commit: test_repository_0b8094
+  source_file: test_repository_readme
+  additions: 2
+  deletions: 0

--- a/api/test/models/source_file_test.rb
+++ b/api/test/models/source_file_test.rb
@@ -22,4 +22,12 @@ class SourceFileTest < ActiveSupport::TestCase
 
     assert_equal({ author: "Jonathan Lalande", commits_count: 1 }, file.main_contributor)
   end
+
+  test "#creation_date" do
+    assert_equal(DateTime.new(2024, 10, 13), source_files(:test_repository_readme).creation_date)
+  end
+
+  test "#last_modification_date" do
+    assert_equal(DateTime.new(2024, 10, 27), source_files(:test_repository_readme).last_modification_date)
+  end
 end


### PR DESCRIPTION
Part of https://github.com/visevol/GithubVisualisation/issues/41

This PR surfaces the `creation_date` and the `last_modification_date` of a file in the response of:
```
GET /repositories/1/files/head/activejob/lib/active_job.rb
```

Example:
![image](https://github.com/user-attachments/assets/7ba89def-10d7-4bae-8580-c84d3d04c351)

Add new methods to SourceFile model
Add the `#creation_date` method. It returns the date of the commit that
introduces this file.

Add the `#last_modification_date` method. It returns the date of the
last commit that modifies that file.


---

Update FilesController#show action
Show the creation_date and last_modification_date of files in the
response of `FilesController#show` action.