### PR TITLE
[Backend] Add file classifier class

### DIFF
--- a/api/lib/file_classifier.rb
+++ b/api/lib/file_classifier.rb
@@ -1,0 +1,34 @@
+class FileClassifier
+  def initialize(filepath)
+    @filepath = filepath
+  end
+
+  FILE_TYPE_EXTENSIONS = {
+    ".c" => "c",
+    ".cc" => "c++",
+    ".cpp" => "c++",
+    ".go" => "go",
+    ".h" => "header file",
+    ".hs" => "haskell",
+    ".java" => "java",
+    ".js" => "javascript",
+    ".json" => "json",
+    ".lhs" => "haskell",
+    ".lock" => "lock file",
+    ".lua" => "lua",
+    ".md" => "markdown",
+    ".py" => "python",
+    ".rb" => "ruby",
+    ".rs" => "rust",
+    ".toml" => "toml",
+    ".txt" => "plain text"
+  }.freeze
+
+  def filetype
+    FILE_TYPE_EXTENSIONS.fetch(extension, "unknown")
+  end
+
+  def extension
+    File.extname(@filepath)
+  end
+end

--- a/api/test/lib/file_classifier_test.rb
+++ b/api/test/lib/file_classifier_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class FileClassifierTest < ActiveSupport::TestCase
+  test "#filetype returns the filetype of commonly known extensions" do
+    assert_equal("ruby", FileClassifier.new("activejob/lib/active_job/version.rb").filetype)
+    assert_equal("javascript", FileClassifier.new("packages/react/src/ReactHooks.js").filetype)
+    assert_equal("c", FileClassifier.new("src/btree.c").filetype)
+    assert_equal("header file", FileClassifier.new("src/btree.h").filetype)
+    assert_equal("c++", FileClassifier.new("router/src/router/src/cluster_metadata.cc").filetype)
+    assert_equal("c++", FileClassifier.new("router/src/router/src/cluster_metadata.cpp").filetype)
+    assert_equal("python", FileClassifier.new("django/core/paginator.py").filetype)
+    assert_equal("rust", FileClassifier.new("src/post.rs").filetype)
+    assert_equal("go", FileClassifier.new("src/net/http/responsecontroller.go").filetype)
+  end
+
+  test "#extension returns the extension of commonly known extensions" do
+    assert_equal(".rb", FileClassifier.new("activejob/lib/active_job/version.rb").extension)
+    assert_equal(".js", FileClassifier.new("packages/react/src/ReactHooks.js").extension)
+    assert_equal(".c", FileClassifier.new("src/btree.c").extension)
+    assert_equal(".h", FileClassifier.new("src/btree.h").extension)
+    assert_equal(".cc", FileClassifier.new("router/src/router/src/cluster_metadata.cc").extension)
+    assert_equal(".cpp", FileClassifier.new("router/src/router/src/cluster_metadata.cpp").extension)
+    assert_equal(".py", FileClassifier.new("django/core/paginator.py").extension)
+    assert_equal(".rs", FileClassifier.new("src/post.rs").extension)
+    assert_equal(".go", FileClassifier.new("src/net/http/responsecontroller.go").extension)
+  end
+
+  test "#filetype returns unknown for unknown filetype" do
+    assert_equal("unknown", FileClassifier.new("src/main.xqc").filetype)
+  end
+end


### PR DESCRIPTION
Base to start categorizing source files.

The classifier accepts a filepath, and returns information about that filepath. For example, its extension and its file type.