### PR TITLE
[Backend] Fix bug where RepositorySyncService don't sync binary files. 

### DIFF
--- a/api/app/services/repository_sync_service.rb
+++ b/api/app/services/repository_sync_service.rb
@@ -170,7 +170,7 @@ class RepositorySyncService
   end
 
   def line_is_a_file_change?(line)
-    Integer(line[0], exception: false)
+    Integer(line[0], exception: false) || line[0] == "-"
   end
 
   def commit_attributes_from_line(line)


### PR DESCRIPTION
Closes: https://github.com/visevol/GithubVisualisation/issues/76

Fix bug where binary files were not picked up by the repository sync service. These files were never synced to our database.